### PR TITLE
Add python version check for csv writing

### DIFF
--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -23,8 +23,8 @@
 # will not be able to troubleshoot or fix. Please use at your own risk!
 
 # don't edit below here unless you know what you're doing!
-import csv, os, sys, configparser
 from __future__ import unicode_literals # issue #25
+import csv, os, sys, configparser
 
 def get_configs():
     # get all our config files
@@ -75,7 +75,6 @@ def get_files():
 def clean_data(file):
     # extract data from transaction file
     delim = g_config["input_delimiter"]
-    delim = delim.encode('utf-8') # issue #25
     output_columns = g_config["output_columns"]
     has_headers = g_config["has_headers"]
     output_data = []
@@ -122,7 +121,15 @@ def write_data(filename, data):
     # write out the new CSV file
     new_filename = g_config["fixed_prefix"] + filename
     print("Writing file: ", new_filename)
-    with open(new_filename, "wb") as file: # issue #25
+    
+    if sys.version_info[0] == 2:  # Not named on 2.6
+        access = 'wb'
+        kwargs = {}
+    else:
+        access = 'wt'
+        kwargs = {'newline':''}
+    
+    with open(new_filename, access, **kwargs) as file: # issue #25
         writer = csv.writer(file)
         for row in data:
             writer.writerow(row)


### PR DESCRIPTION
Issue #25 
Add python version check for csv writing
Also remove delimiter encoding as shouldn't be needed with unicode_literals and was causing me errors -
 wasn't working anyway according to @torbengb.
Also move `__future__` to top of file to prevent error.

```
SyntaxError: from __future__ imports must occur at the beginning of the file
TypeError: "delimiter" must be string, not bytes
```