### PR TITLE
Automatically fill empty memo field with payee info

### DIFF
--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -21,8 +21,6 @@ Input Columns = Date,Payee,Outflow,Inflow,Running Balance
 Output Columns = Date,Payee,Category,Memo,Outflow,Inflow
 Output Filename Prefix = fixed_
 Output Filename Extension = .csv
-# Misc.
-Use Payees for Memo = False
 # Post-processing
 Delete Source File = True
 
@@ -50,7 +48,6 @@ Use Payees for Memo = True
 [IE Bank of Ireland]
 Source Filename Pattern = TransactionExport
 Input Columns = Date,Payee,Outflow,Inflow,skip
-Use Payees for Memo = True
 Source Path = 
 
 [UK Co-operative Bank]

--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -93,7 +93,6 @@ def fix_row(row):
     # fixes a row of our file
     output = []
     for header in g_config["output_columns"]:
-        header = header_swap(header)
         try:
             # check to see if our output header exists in input
             index = g_config["input_columns"].index(header)
@@ -111,13 +110,6 @@ def valid_row(row):
     if row[inflow_index] == "" and row[outflow_index] == "":
         return False
     return True
-    
-def header_swap(header):
-    # replaces one column's value with another if required
-    if g_config["payee_memo_swap"] is True:
-        if header == "Memo":
-            return "Payee"
-    return header
     
 def auto_memo(row):
     # auto fill empty memo field with payee info

--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -39,7 +39,6 @@ def fix_conf_params(section):
     config["input_delimiter"] = section["Source CSV Delimiter"]
     config["has_headers"] = section.getboolean("Source Has Column Headers")
     config["delete_original"] = section.getboolean("Delete Source File")
-    config["payee_memo_swap"] = section.getboolean("Use Payees for Memo")    
         
     # # Direct bank download
     # Bank Download = False

--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -76,7 +76,7 @@ def clean_data(file):
         # make each row of our new transaction file
         for row in transaction_reader:
             # add new row to output list
-            fixed_row = fix_row(row)
+            fixed_row = auto_memo(fix_row(row))
             # check our row isn't a null transaction
             if valid_row(fixed_row) is True:
                 output_data.append(fixed_row)
@@ -120,7 +120,7 @@ def header_swap(header):
     return header
     
 def auto_memo(row):
-    # auto fill empty memo field with payee info if required
+    # auto fill empty memo field with payee info
     payee_index = g_config["output_columns"].index("Payee")
     memo_index = g_config["output_columns"].index("Memo")
     if row[memo_index] == "":

--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -118,7 +118,15 @@ def header_swap(header):
         if header == "Memo":
             return "Payee"
     return header
-                
+    
+def auto_memo(row):
+    # auto fill empty memo field with payee info if required
+    payee_index = g_config["output_columns"].index("Payee")
+    memo_index = g_config["output_columns"].index("Memo")
+    if row[memo_index] == "":
+        row[memo_index] = row[payee_index]
+    return row
+    
 def write_data(filename, data):
     # write out the new CSV file
     new_filename = g_config["fixed_prefix"] + filename


### PR DESCRIPTION
Issue #28. Preserves existing memo fields. Only fills in memo field with payee info if memo field is empty. Useful for preserving payee info once renamed in YNAB.