### PR TITLE
Feature/157 stylecheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,14 @@ python:
   - "3.7-dev" # 3.7 development branch
   - "nightly"
 # command to run tests
+install: 
+  - pip install flake8
+
 script:
   - python -m unittest discover
-  - pip install flake8
-  - flake8 --builtins=FileNotFoundError,unicode
+  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then flake8 --builtins=FileNotFoundError
+  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then flake8 --builtins=unicode
+  
 notifications:
   email: false
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ python:
 # command to run tests
 script:
   - python -m unittest discover
-    - pip install flake8
+  - pip install flake8
   - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then flake8 --builtins=FileNotFoundError; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then flake8 --builtins=unicode; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3* ] && [$TRAVIS_PYTHON_VERSION != 3.2]]; then flake8 --builtins=unicode; fi
   
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - python -m unittest discover
   - pip install flake8
   - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then flake8 --builtins=FileNotFoundError; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then flake8 --builtins=unicode; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3* ] AND [ $TRAVIS_PYTHON_VERSION != 3.2 ]]; then flake8 --builtins=unicode; fi
   
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - python -m unittest discover
   - pip install flake8
   - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then flake8 --builtins=FileNotFoundError; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 3* ] && [$TRAVIS_PYTHON_VERSION != 3.2]]; then flake8 --builtins=unicode; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then flake8 --builtins=unicode; fi
   
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,11 @@ python:
   - "3.7-dev" # 3.7 development branch
   - "nightly"
 # command to run tests
-install: 
-  - pip install flake8
-
 script:
+  - pip install flake8
   - python -m unittest discover
-  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then flake8 --builtins=FileNotFoundError
-  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then flake8 --builtins=unicode
+  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then flake8 --builtins=FileNotFoundError; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then flake8 --builtins=unicode; fi
   
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ python:
   - "nightly"
 # command to run tests
 script:
-  - pip install flake8
   - python -m unittest discover
+    - pip install flake8
   - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then flake8 --builtins=FileNotFoundError; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then flake8 --builtins=unicode; fi
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - python -m unittest discover
   - pip install flake8
   - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then flake8 --builtins=FileNotFoundError; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]] AND [[ $TRAVIS_PYTHON_VERSION != 3.2 ]]; then flake8 --builtins=unicode; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]] && [[ $TRAVIS_PYTHON_VERSION != 3.2 ]]; then flake8 --builtins=unicode; fi
   
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ python:
   - "3.7-dev" # 3.7 development branch
   - "nightly"
 # command to run tests
-before_install: pip install flake8
 script:
   - python -m unittest discover
+  - pip install flake8
   - flake8 --builtins=FileNotFoundError,unicode
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - python -m unittest discover
   - pip install flake8
   - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then flake8 --builtins=FileNotFoundError; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 3* ] AND [ $TRAVIS_PYTHON_VERSION != 3.2 ]]; then flake8 --builtins=unicode; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]] AND [[ $TRAVIS_PYTHON_VERSION != 3.2 ]]; then flake8 --builtins=unicode; fi
   
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,10 @@ python:
   - "3.7-dev" # 3.7 development branch
   - "nightly"
 # command to run tests
+before_install: pip install flake8
 script:
   - python -m unittest discover
+  - flake8
 notifications:
   email: false
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ python:
 before_install: pip install flake8
 script:
   - python -m unittest discover
-  - flake8
+  - flake8 --builtins=FileNotFoundError
 notifications:
   email: false
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ python:
 before_install: pip install flake8
 script:
   - python -m unittest discover
-  - flake8 --builtins=FileNotFoundError
+  - flake8 --builtins=FileNotFoundError,unicode
 notifications:
   email: false
   webhooks:

--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -20,7 +20,6 @@ from os.path import abspath, join, dirname, basename
 import codecs
 import csv
 import os
-import sys
 import importlib
 import re
 

--- a/plugins/nl-rabobank.py
+++ b/plugins/nl-rabobank.py
@@ -2,6 +2,7 @@
 
 from bank2ynab import B2YBank, CrossversionCsvReader
 
+
 class NLRabobankPlugin(B2YBank):
     def __init__(self, config_object, is_py2):
         super(NLRabobankPlugin, self).__init__(config_object, is_py2)
@@ -12,7 +13,6 @@ class NLRabobankPlugin(B2YBank):
         output_columns = self.config["output_columns"]
         # we know it should have headers, but we respect the setting
         header_rows = self.config["header_rows"]
-        footer_rows = self.config["footer_rows"]
         output_data = []
 
         with CrossversionCsvReader(file_path,
@@ -25,9 +25,10 @@ class NLRabobankPlugin(B2YBank):
                 tmp = {}
                 """
                 DATE STUFF:
-                YNAB's date format is "DD/MM/YYYY". 
+                YNAB's date format is "DD/MM/YYYY".
                 This bank's date format is "YYYMMDD" without delimiters.
-                Moving the substrings into the proper order: https://stackoverflow.com/a/663175/20571
+                Moving the substrings into the proper order: 
+                https://stackoverflow.com/a/663175/20571
                 """
                 date = row[2]
                 tmp["Date"] = date[6:7] + '/' + date[4:5] + '/' + date[0:3]

--- a/plugins/nl-rabobank.py
+++ b/plugins/nl-rabobank.py
@@ -27,7 +27,7 @@ class NLRabobankPlugin(B2YBank):
                 DATE STUFF:
                 YNAB's date format is "DD/MM/YYYY".
                 This bank's date format is "YYYMMDD" without delimiters.
-                Moving the substrings into the proper order: 
+                Moving the substrings into the proper order:
                 https://stackoverflow.com/a/663175/20571
                 """
                 date = row[2]

--- a/plugins/null.py
+++ b/plugins/null.py
@@ -53,7 +53,7 @@ class NullBank(B2YBank):
 
 def build_bank(config, is_py2):
     """ This factory function is called from the main program,
-    and expected to return a B2YBank subclass. 
+    and expected to return a B2YBank subclass.
     Without this, the module will fail to load properly.
 
     :param config: dict containing all available configuration parameters
@@ -61,4 +61,3 @@ def build_bank(config, is_py2):
     :return: a B2YBank subclass instance
     """
     return NullBank(config, is_py2)
-    

--- a/plugins/null.py
+++ b/plugins/null.py
@@ -52,11 +52,13 @@ class NullBank(B2YBank):
 
 
 def build_bank(config, is_py2):
-    """ This factory function is called from the main program, and expected to
-    return a B2YBank subclass. Without this, the module will fail to load properly.
+    """ This factory function is called from the main program,
+    and expected to return a B2YBank subclass. 
+    Without this, the module will fail to load properly.
 
     :param config: dict containing all available configuration parameters
     :param is_py2: boolean indicating whether we are running under Python 2.x
     :return: a B2YBank subclass instance
     """
     return NullBank(config, is_py2)
+    

--- a/plugins/plugin-template.py
+++ b/plugins/plugin-template.py
@@ -1,8 +1,9 @@
 # Step 1: See https://github.com/torbengb/bank2ynab/wiki/WorkingWithPlugins
 # Step 2: Copy this template into a new file.
-# Step 3: In all of the below, replace "TemplateBank" with a descriptive name for the actual bank this plugin is for.
+# Step 3: Replace "YourActualBank" below with a descriptive bank name
 
 from bank2ynab import B2YBank, CrossversionCsvReader
+
 
 class YourActualBankPlugin(B2YBank):
     def __init__(self, config_object, is_py2):
@@ -13,7 +14,7 @@ class YourActualBankPlugin(B2YBank):
         delim = self.config["input_delimiter"]
         output_columns = self.config["output_columns"]
         # we know it should have headers, but we respect the setting
-        has_headers = self.config["has_headers"]
+        header_rows = self.config["header_rows"]
         output_data = []
 
         with CrossversionCsvReader(file_path,
@@ -21,32 +22,31 @@ class YourActualBankPlugin(B2YBank):
                                    delimiter=delim) as reader:
             for index, row in enumerate(reader):
                 # skip first row if headers
-                if index == 0 and has_headers:
+                if index == 0 and header_rows != 0:
                     continue
                 tmp = {}
-# DATE STUFF:
-# YNAB's date format is "DD/MM/YYYY". 
-# Use substrings to move date elements into the proper order: https://stackoverflow.com/a/663175/20571
-                date = row[9]
-# In your own plugin there should be exactly 1 of these lines. Remove the ones you don't need, and edit as needed.
-                tmp["Date"] = date[6:7] + '/' + date[4:5] + '/' + date[0:3] # when source format is "YYYYMMDD" without delimiters.
-                tmp["Date"] = date[0:1] + '/' + date[2:3] + '/' + date[4:7] # when source format is "DDMMYYYY" without delimiters.
-                tmp["Date"] = date[0:1] + '/' + date[3:4] + '/' + date[6:9] # when source format is "DD-MM-YYYY" with delimiters.
-# PAYEE STUFF:
-                tmp["Payee"] = row[9]
-# CATEGORY STUFF:
+                """
+                DATE STUFF:
+                YNAB's date format is "DD/MM/YYYY".
+                This bank's date format is "YYYMMDD" without delimiters.
+                Moving the substrings into the proper order:
+                https://stackoverflow.com/a/663175/20571
+                """
+                date = row[2]
+                tmp["Date"] = date[6:7] + '/' + date[4:5] + '/' + date[0:3]
+                # PAYEE STUFF:
+                tmp["Payee"] = row[7]
+                # CATEGORY STUFF:
                 tmp["Category"] = ''
-# MEMO STUFF:
-                tmp["Memo"] = row[9]
-# AMOUNT STUFF:
-                tmp["Inflow"] = row[9]
-                tmp["Outflow"] = row[9]
+                # MEMO STUFF:
+                tmp["Memo"] = row[11]
+                # AMOUNT STUFF:
                 # C means inflow (credit), D means outflow (debit)
-                if row[10] == 'C':
+                if row[4] == 'C':
                     tmp["Outflow"] = ''
-                    tmp["Inflow"] = row[9]
+                    tmp["Inflow"] = row[5]
                 else:
-                    tmp["Outflow"] = row[9]
+                    tmp["Outflow"] = row[5]
                     tmp["Inflow"] = ''
 
                 # respect Output Columns option
@@ -55,6 +55,7 @@ class YourActualBankPlugin(B2YBank):
                     out_row[index] = tmp.get(key, "")
                 output_data.append(out_row)
         return output_data
+
 
 def build_bank(config, is_py2):
     return YourActualBankPlugin(config, is_py2)

--- a/plugins/swedebank.py
+++ b/plugins/swedebank.py
@@ -2,6 +2,7 @@
 
 from bank2ynab import B2YBank, CrossversionCsvReader
 
+
 class SwedebankPlugin(B2YBank):
     def __init__(self, config_object, is_py2):
         super(SwedebankPlugin, self).__init__(config_object, is_py2)
@@ -12,7 +13,6 @@ class SwedebankPlugin(B2YBank):
         output_columns = self.config["output_columns"]
         # we know it should have headers, but we respect the setting
         header_rows = self.config["header_rows"]
-        footer_rows = self.config["footer_rows"]
         output_data = []
 
         with CrossversionCsvReader(file_path,

--- a/test/test_B2YBank.py
+++ b/test/test_B2YBank.py
@@ -17,6 +17,7 @@ except ImportError:
     import ConfigParser as configparser
     import cStringIO
 
+
 class TestB2YBank(TestCase):
 
     TESTCONFPATH = join("test-data", "test.conf")
@@ -39,7 +40,7 @@ class TestB2YBank(TestCase):
 
     def test_get_files(self):
         """ Test it's finding the right amount of files"""
-        # if you need more tests, add sections to test.conf and then specify them here
+        # if you need more tests, add sections to test.conf & specify them here
         for section_name, num_files in [
                 ("test_num_files", 2),
                 ("test_num_files_noexist", 0),
@@ -58,7 +59,7 @@ class TestB2YBank(TestCase):
             self.assertEqual(len(files), num_files)
 
     def test_read_data(self):
-        # if you need more tests, add sections to test.conf and then specify them here
+        # if you need more tests, add sections to test.conf & specify them here
         for section_name, num_records, fpath in [
                 ("test_record_i18n", 74, "test_raiffeisen_01.csv"),
                 ("test_record_headers", 74, "test_headers.csv")
@@ -69,7 +70,7 @@ class TestB2YBank(TestCase):
             self.assertEqual(len(records), num_records)
 
     def test_write_data(self):
-        # if you need more tests, add sections to test.conf and then specify them here
+        # if you need more tests, add sections to test.conf & specify them here
         # todo: incorporate multiple-file scenarios
         for section_name, num_records, fpath in [
             ("test_record_i18n", 74, "fixed_test_raiffeisen_01.csv"),

--- a/test/test_B2YBank.py
+++ b/test/test_B2YBank.py
@@ -10,12 +10,6 @@ from plugins.null import NullBank
 from test.utils import get_test_confparser
 
 _PY2 = False
-try:
-    import configparser
-except ImportError:
-    _PY2 = True
-    import ConfigParser as configparser
-    import cStringIO
 
 
 class TestB2YBank(TestCase):

--- a/test/utils.py
+++ b/test/utils.py
@@ -3,6 +3,7 @@ from os.path import join, abspath, dirname
 PRODPATH = "bank2ynab.conf"
 TESTCONFPATH = join("test-data", "test.conf")
 
+
 def get_test_confparser():
     py2 = False
     try:

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,4 +1,4 @@
-from os.path import join, abspath, dirname
+from os.path import join
 
 PRODPATH = "bank2ynab.conf"
 TESTCONFPATH = join("test-data", "test.conf")


### PR DESCRIPTION
Fixes #157 

Running into two errors which I don't really know how to solve.

One is that the Python 2 build is failing for some reason. It's flagging the old encoding error, despite me not changing anything about how encoding is handled.
```
Traceback (most recent call last):
  File "/home/travis/build/torbengb/bank2ynab/test/test_B2YBank.py", line 63, in test_read_data
    records = b.read_data(join("test-data", fpath))
  File "/home/travis/build/torbengb/bank2ynab/bank2ynab.py", line 342, in read_data
    delimiter=delim) as transaction_reader:
  File "/home/travis/build/torbengb/bank2ynab/bank2ynab.py", line 72, in __enter__
    self.stream = open(self.file_path, encoding=encoding)
TypeError: 'encoding' is an invalid keyword argument for this function
```

The other is that there seems to be a bug in flake8 for Python 3.2 which prevents it from handling exemptions correctly - the exemption I have excludes the check for "unicode" which is in to allow Python 2.x compatibility, but isn't used in Python 3. 

```
$ flake8 --builtins=FileNotFoundError,unicode
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.2.6/bin/flake8", line 7, in <module>
    from flake8.main.cli import main
  File "/home/travis/virtualenv/python3.2.6/lib/python3.2/site-packages/flake8/main/cli.py", line 2, in <module>
    from flake8.main import application
  File "/home/travis/virtualenv/python3.2.6/lib/python3.2/site-packages/flake8/main/application.py", line 15, in <module>
    from flake8.options import aggregator, config
  File "/home/travis/virtualenv/python3.2.6/lib/python3.2/site-packages/flake8/options/aggregator.py", line 8, in <module>
    from flake8.options import config
  File "/home/travis/virtualenv/python3.2.6/lib/python3.2/site-packages/flake8/options/config.py", line 63
    if isinstance(files, (str, type(u''))):
                                      ^
SyntaxError: invalid syntax
```