### PR TITLE
Feature/bugfix 165 row deletion conflict

### DIFF
--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -169,6 +169,7 @@ class UnicodeReader:
     def line_num(self):
         return self.reader.line_num()
 
+
 class UnicodeWriter:
     def __init__(self, f, dialect=csv.excel, encoding="utf-8", **kwds):
         self.queue = cStringIO.StringIO()

--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -161,7 +161,7 @@ class UnicodeReader:
     def next(self):
         row = self.reader.next()
         return [unicode(s, "utf-8") for s in row]
-        
+
     def line_num(self):
         return self.reader.line_num()
 

--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -351,16 +351,20 @@ class B2YBank(object):
                                    delimiter=delim) as transaction_reader:
             # make each row of our new transaction file
             for row in transaction_reader:
-                # check if we need to process Inflow or Outflow flags
-                if len(cd_flags) == 3:
-                    row = self._cd_flag_process(row)
-                # add new row to output list
-                fixed_row = self._auto_memo(self._fix_row(row))
-                # check our row isn't a null transaction
-                if self._valid_row(fixed_row) is True:
-                    output_data.append(fixed_row)
-            # strip out header & footer rows
-            output_data = output_data[header_rows:-footer_rows or None]
+                line = transaction_reader.line_num
+                print(line)
+                # skip header & footer rows [TODO FOOTER ROWS]
+                if line > header_rows:
+                    # check if we need to process Inflow or Outflow flags
+                    if len(cd_flags) == 3:
+                        row = self._cd_flag_process(row)
+                    # add new row to output list
+                    fixed_row = self._auto_memo(self._fix_row(row))
+                    # check our row isn't a null transaction
+                    if self._valid_row(fixed_row) is True:
+                        output_data.append(fixed_row)
+                else: # debug to see if it's working
+                    print("header: {}".format(line))
             # add in column headers
             output_data.insert(0, output_columns)
         print("Parsed {} lines".format(len(output_data)))

--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -351,7 +351,7 @@ class B2YBank(object):
                                    self._is_py2,
                                    delimiter=delim) as row_count_reader:
             row_count = sum(1 for row in row_count_reader)
-        
+
         with CrossversionCsvReader(file_path,
                                    self._is_py2,
                                    delimiter=delim) as transaction_reader:

--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -162,12 +162,12 @@ class UnicodeReader:
         row = self.reader.next()
         return [unicode(s, "utf-8") for s in row]
 
-    def line_num(self):
-        return self.reader.line_num()
-
     def __iter__(self):
         return self
 
+    @property
+    def line_num(self):
+        return self.reader.line_num()
 
 class UnicodeWriter:
     def __init__(self, f, dialect=csv.excel, encoding="utf-8", **kwds):

--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -161,6 +161,9 @@ class UnicodeReader:
     def next(self):
         row = self.reader.next()
         return [unicode(s, "utf-8") for s in row]
+        
+    def line_num(self):
+        return self.reader.line_num()
 
     def __iter__(self):
         return self


### PR DESCRIPTION
Fixes #165 

Skip header & footer rows when including rows in output. This occurs before row validation, preventing rows being deleted from messing up the header & footer count.