### PR TITLE
#184, proper regexes for dates and times.

### DIFF
--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -35,7 +35,19 @@ Plugin =
 # Just make a new [section heading] and copy only the lines from above that need a non-default value.
 # Please keep this sorted alphabetically by [country + bank name] for easier maintenance.
 #####################################################################################################
-# DATE FORMATS:
+# FILENAME REGEX DATE FORMATS:
+# YYYY       ([12][0-9]{3})
+# mm         (0[1-9]|1[0-2])
+# dd         (0[1-9]|[12]\d|3[01])
+# YYYYmmdd   (([12][0-9]{3})(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01]))
+# YYYY-mm-dd (([12][0-9]{3})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))
+# HH         (0[1-9]|1[0-9]|2[0-3])
+# MM         ([0-5][0-9])
+# SS         ([0-5][0-9])
+# HHMMSS     ((0[1-9]|1[0-9]|2[0-3])([0-5][0-9])([0-5][0-9]))
+# HH:MM:SS   ((0[1-9]|1[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]))
+#####################################################################################################
+# DATE COLUMN FORMATS:
 # %%y   2-digit year
 # %%Y   4-digit year
 # %%m   2-digit month
@@ -49,7 +61,7 @@ Plugin =
 [AT Raiffeisen Bank]
 # elbi_umsaetze_20123456789012.csv
 Use Regex For Filename = True
-Source Filename Pattern = elbi_umsaetze_20[0-9]{12}
+Source Filename Pattern = elbi_umsaetze_(([12][0-9]{3})(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01]))((0[1-9]|1[0-9]|2[0-3])([0-5][0-9])([0-5][0-9]))
 Source CSV Delimiter = ;
 Header Rows = 0
 Input Columns = Date,Memo,skip,Inflow,skip,skip,skip
@@ -57,7 +69,7 @@ Input Columns = Date,Memo,skip,Inflow,skip,skip,skip
 [AT Raiffeisen VISA]
 # finstatus_20123456789012.csv
 Use Regex For Filename = True
-Source Filename Pattern = finstatus_20[0-9]{12}
+Source Filename Pattern = finstatus_(([12][0-9]{3})(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01]))((0[1-9]|1[0-9]|2[0-3])([0-5][0-9])([0-5][0-9]))
 Source CSV Delimiter = ;
 Header Rows = 0
 Input Columns = skip,Date,Memo,skip,skip,skip,Inflow
@@ -117,7 +129,7 @@ Input Columns = Date,Payee,skip,skip,skip,Inflow,skip,skip
 # source: survey response #15
 # 20123456-20123456.csv
 Use Regex For Filename = True
-Source Filename Pattern = 20[0-9]{6}-20[0-9]{6}
+Source Filename Pattern = (([12][0-9]{3})(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01]))-(([12][0-9]{3})(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01]))
 Input Columns = Date,Payee,skip,skip,skip,skip,Inflow,skip,skip,skip
 
 [DE Ostseesparkasse Rostock checking]
@@ -157,7 +169,7 @@ Input Columns = Date,Payee,skip,Inflow,skip
 # source: survey response #16
 # Transaction_Export_12.12.2012_12.12.csv
 Use Regex For Filename = True
-Source Filename Pattern = Transaction_Export_[0-9]{2}.[0-9]{2}.20[0-9]{2}_[0-9]{2}.[0-9]{2}
+Source Filename Pattern = Transaction_Export_((0[1-9]|[12]\d|3[01]).(0[1-9]|1[0-2]).([12][0-9]{3}))_((0[1-9]|1[0-9]|2[0-3]).([0-5][0-9]))
 Input Columns = skip,Date,Payee,Inflow,Outflow,skip,skip
 Use Payees for Memo = True
 
@@ -175,7 +187,7 @@ Input Columns = Date,skip,skip,skip,skip,Memo,skip,skip,Inflow,Outflow,skip
 [NL ING]
 # NL12INGB123456789_12_12_2012_12_12_2012.csv
 Use Regex for Filename = True
-Source Filename Pattern = NL[0-9]{2}INGB[0-9]{9}_[0-9]{2}_[0-9]{2}_20[0-9]{2}_[0-9]{2}_[0-9]{2}_20[0-9]{2}
+Source Filename Pattern = NL[0-9]{2}INGB[0-9]{9}_((0[1-9]|[12]\d|3[01])_(0[1-9]|1[0-2])_([12][0-9]{3}))_((0[1-9]|[12]\d|3[01])_(0[1-9]|1[0-2])_([12][0-9]{3}))
 Header Rows = 1
 Footer Rows = 0
 Input Columns = Date,Payee,skip,skip,skip,CDFlag,Amount,skip,Memo
@@ -203,7 +215,7 @@ Input Columns = Date,Payee,skip,Outflow,Inflow
 # source: Issue #144
 # Feb 12-2012 thru Apr 12-2012 transactions.csv
 Use Regex For Filename = True
-Source Filename Pattern = [A-Z][a-z]{2} [0-9]{2}-20[0-9]{2} thru [A-Z][a-z]{2} [0-9]{2}-20[0-9]{2} transactions
+Source Filename Pattern = [A-Z][a-z]{2} [0-9]{2}-([12][0-9]{3}) thru [A-Z][a-z]{2} [0-9]{2}-([12][0-9]{3}) transactions
 Header Rows = 1
 Input Columns = Date,Payee,Memo,skip,skip,Inflow
 
@@ -236,14 +248,14 @@ Input Columns = skip,skip,Date,Payee,Memo,Inflow,skip,CDFlag,skip,skip,skip,skip
 Inflow or Outflow Indicator = 7,K,D
 
 [UK Co-operative Bank]
-# 123456_12345678_2012-12-12.csv
+# 123456_12345678_2018-12-31.csv
 Use Regex for Filename = True
-Source Filename Pattern = [0-9]{6}_[0-9]{8}_20[0-9]{2}-[0-9]{2}-[0-9]{2}
+Source Filename Pattern = [0-9]{6}_[0-9]{8}_(([12][0-9]{3})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))
 Input Columns = Date,Payee,Memo,Inflow,Outflow,skip
 
 [UK Monzo checking]
 # MonzoDataExport_February2018_2018-02-26_174335.csv
-Source Filename Pattern = MonzoDataExport_(January|February|March|April|May|June|July|August|September|October|November|December)20[0-9]{2}_20[0-9]{2}-[0-9]{2}-[0-9]{2}_[0-9]{6}
+Source Filename Pattern = MonzoDataExport_(January|February|March|April|May|June|July|August|September|October|November|December)([12][0-9]{3})_(([12][0-9]{3})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))_((0[1-9]|1[0-9]|2[0-3])([0-5][0-9])([0-5][0-9]))
 Use Regex for Filename = True
 Input Columns = skip,Date,Inflow,skip,skip,skip,Category,skip,Payee,skip,Memo,skip
 Date Format = %%Y-%%m-%%d %%H:%%M:%%S +0000
@@ -258,7 +270,7 @@ Date Format = %%d %%b %%y
 
 [UK first direct checking]
 # 20123456_12345678.csv
-Source Filename Pattern = 20[0-9]{6}_[0-9]{8}
+Source Filename Pattern = (([12][0-9]{3})(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01]))_[0-9]{8}
 Use Regex for Filename = True
 Input Columns = Date,Payee,Inflow,skip
 


### PR DESCRIPTION
I like the exactness of this approach, but I admit that the long regex strings look daunting. That's why I also added the samples in the comment section. I'm aware that [you disagreed here](https://github.com/torbengb/bank2ynab/issues/182#issuecomment-368596883) but I'm testing this anyway... 

I feel it would be careless to specify the patterns only as precisely as necessary, because when every new format changes the definition of "as necessary". We're already seeing some conflicts, and leaving the formats vaguely referenced opens us up to mismatches when future formats arrive. I think there's value in being precise, especially as the number of supported formats increase. 