### PR TITLE
Change cd_flag_process back to pure text

### DIFF
--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -465,9 +465,11 @@ class B2YBank(object):
         indicator_col = int(cd_flags[0])
         outflow_flag = cd_flags[2]
         inflow_col = self.config["input_columns"].index("Inflow")
-        # if this row is indicated to be outflow, multiply Inflow by -1
+        outlow_col = self.config["input_columns"].index("Outflow")
+        # if this row is indicated to be outflow, move amount to outflow
         if row[indicator_col] == outflow_flag:
-            row[inflow_col] = str(-1 * float(row[inflow_col]))
+            row[outflow_col] = row[inflow_col]
+            row[inflow_col] = ""
         return row
 
     def write_data(self, filename, data):

--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -465,7 +465,7 @@ class B2YBank(object):
         indicator_col = int(cd_flags[0])
         outflow_flag = cd_flags[2]
         inflow_col = self.config["input_columns"].index("Inflow")
-        outlow_col = self.config["input_columns"].index("Outflow")
+        outflow_col = self.config["input_columns"].index("Outflow")
         # if this row is indicated to be outflow, move amount to outflow
         if row[indicator_col] == outflow_flag:
             row[outflow_col] = row[inflow_col]


### PR DESCRIPTION
New behaviour - now moves rows marked as outflows from inflow column to outflow column instead of making a negative inflow
Fixes #207 - with thanks to @toyg for pointing out the error